### PR TITLE
make "distro-agnostic" with Ubuntu distros

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           Copy-Item -Path .\glt_launcher.exe -Destination .\dist\gpu_lookup\src\
           Copy-Item -Path .\resources\* -Destination .\dist\gpu_lookup\src\resources\icons -Recurse
           Copy-Item -Path .\GUI.xaml -Destination .\dist\gpu_lookup\src\
-          Copy-Item .\glt_launcher.ps1,.\gpu_lookup_tableGUI.ps1,.\help_man.ps1 -Destination .\dist\gpu_lookup\src\
+          Copy-Item .\glt_launcher.ps1,.\gpu_lookup_tableGUI.ps1,.\p7zip_util.ps1,.\help_man.ps1 -Destination .\dist\gpu_lookup\src\
       - name: Compress package directory
         shell: powershell
         run: |

--- a/GUI.xaml
+++ b/GUI.xaml
@@ -34,7 +34,7 @@
             </MenuItem>
         </Menu>
         <Grid Margin="10,10,6,8">
-            <Viewbox x:Name="SVGLogoViewBox" Height="80" Margin="0,200,0,200" Opacity="0.75" Width="200">
+            <Viewbox x:Name="SVGLogoViewBox" Height="80" Margin="0,210,0,200" Opacity="0.75" Width="200">
                 <Grid>
                     <!--<Path Fill ="#eb993b" Data="M 194.32,0 V 100.82 H 96.65 V 199.3 H 0 V 315.38 H 314 V 0 Z M 96.65,300.12 H 15.26 v -85.56 h 81.39 z m 97.67,0 h -80.58 v -85.56 h 80.58 z m 0,-100.82 h -80.58 v -83.22 h 80.58 z M 298.7,300.12 h -88.51 v -85.56 h 88.51 z m 0,-100.82 h -88.51 v -83.22 h 88.51 z m 0,-98.48 H 210.19 V 15.26 h 88.51 z"/>-->
                     <Rectangle Fill="#eb993b" Margin="215,25,1450,0" Height="85" VerticalAlignment="Top" />
@@ -64,11 +64,13 @@
             <Label Content="GPU Lookup Table GUI" HorizontalAlignment="Center" Margin="0,10,0,0" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" Foreground="#FFEEEEEE" Width="186" Height="30"/>
             <TextBox x:Name="TextRemoteIP" HorizontalAlignment="Center" Margin="0,60,0,0" Text="192.168." VerticalAlignment="Top" Width="130" Background="White" FontStyle="Italic" TextAlignment="Center" Height="18" AutoWordSelection="True" Cursor="IBeam" ToolTip="Enter remote IP address." InputScope="Url" FontFamily="Consolas" MaxLength="15" MaxLines="1" FontSize="14"/>
             <Label Content="Credentials" HorizontalAlignment="Center" Margin="0,100,0,0" VerticalAlignment="Top" Foreground="#FFEEEEEE" FontSize="15" FontWeight="Bold"/>
-            <Label Content="Password: " HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="#FFEEEEEE" Width="74" Height="24" FontWeight="Normal" Margin="64,136,0,0"/>
-            <PasswordBox x:Name="PasswdBox" HorizontalAlignment="Left" Margin="150,140,0,0" VerticalAlignment="Top" Width="120" ToolTip="Leave blank to use the set default password"/>
-            <Label x:Name="LabelFilterTitle" Content="Filtering" HorizontalAlignment="Center" Margin="0,196,0,0" VerticalAlignment="Top" Foreground="#FFEEEEEE" FontSize="15" FontWeight="Bold"/>
-            <Label x:Name="LabelFilter" Content="Filter List: " HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="#FFEEEEEE" Width="74" Height="24" FontWeight="Normal" Margin="64,232,0,0"/>
-            <TextBox x:Name="TextFilterList" HorizontalAlignment="Left" Margin="150,236,0,0" VerticalAlignment="Top" Width="120" Cursor="IBeam" AutoWordSelection="True" FontStyle="Italic" TextAlignment="Left" Height="18" ToolTip="Enter GPU device index(es) (comma-separated)." MaxLines="1" FontSize="14"/>
+            <Label Content="Username: " HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="#FFEEEEEE" Width="81" Height="24" FontWeight="Normal" Margin="64,136,0,0"/>
+            <TextBox x:Name="TextUser" HorizontalAlignment="Left" Margin="150,141,0,0" VerticalAlignment="Top" Width="120" ToolTip="Leave blank to use the set default user ('user')"/>
+            <Label Content="Password : " HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="#FFEEEEEE" Width="81" Height="24" FontWeight="Normal" Margin="64,160,0,0"/>
+            <PasswordBox x:Name="PasswdBox" HorizontalAlignment="Left" Margin="150,165,0,0" VerticalAlignment="Top" Width="120" ToolTip="Leave blank to use the set default password"/>
+            <Label x:Name="LabelFilterTitle" Content="Filtering" HorizontalAlignment="Center" Margin="0,206,0,0" VerticalAlignment="Top" Foreground="#FFEEEEEE" FontSize="15" FontWeight="Bold"/>
+            <Label x:Name="LabelFilter" Content="Filter List: " HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="#FFEEEEEE" Width="74" Height="24" FontWeight="Normal" Margin="64,238,0,0"/>
+            <TextBox x:Name="TextFilterList" HorizontalAlignment="Left" Margin="150,243,0,0" VerticalAlignment="Top" Width="120" Cursor="IBeam" AutoWordSelection="True" FontStyle="Italic" TextAlignment="Left" Height="18" ToolTip="Enter GPU device index(es) (comma-separated)." MaxLines="1" FontSize="14"/>
             <Label Content="Quick Options" HorizontalAlignment="Center" VerticalAlignment="Top" Foreground="#FFEEEEEE" FontSize="15" FontWeight="Bold" Margin="0,280,0,0"/>
             <CheckBox x:Name="CheckAll" Content="Show All" HorizontalAlignment="Center" Margin="0,320,0,0" VerticalAlignment="Top" Foreground="#FFEEEEEE" ToolTip="Shows all devices. Uncheck to only show GI/MISSING cards." IsChecked="True"/>
             <CheckBox x:Name="CheckBypassAM" Content="Bypass AM Validation" HorizontalAlignment="Center" Margin="0,345,0,0" VerticalAlignment="Top" Foreground="#FFEEEEEE" ToolTip="Disables host validation with Awesome Miner API. NOTE: Will disable GI Examination" IsChecked="True"/>

--- a/glt_launcher.ps1
+++ b/glt_launcher.ps1
@@ -356,6 +356,7 @@ $AcceptButton.add_click(
                 # input
                 input       = [PSCustomObject]@{
                     remoteIP   = $TextRemoteIP.Text
+                    username   = $TextUser.Text
                     passwd     = if ($PasswdBox.Password.Length) { ($PasswdBox.SecurePassword | ConvertFrom-SecureString) } else { '' }
                     filterList = $TextFilterList.Text
                 }

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -669,10 +669,11 @@ Function Show-Column
 {
     param (
         [Parameter(Mandatory, ValueFromPipeline)][string]$line,
+        [string]$Delimiter,
         [int]$Column
     )
-
-    ($line -split ' ')[$Column]
+    if (! $Delimiter) { $Delimiter = ' ' }
+    ($line -split $Delimiter)[$Column]
 }
 
 

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -445,7 +445,7 @@ Function Request-Data
     {
         $gi_info = "head -n 30 /var/log/awesome/$($miner.softwareType)*/console_output.txt > /tmp/console_output.txt;"
     }
-    $payload = "$bios_info $gi_info lsmod | grep -oE 'nvidia|amdgpu' -m 1 > /tmp/gpu_driver.txt; cat `$GPU_DETECT_JSON > /tmp/gpu_detect.json; sudo dmidecode -s baseboard-product-name > /tmp/mb_product_name.txt; sudo dmidecode -t 9 > /tmp/dmidecodet9.txt; sudo biosdecode > /tmp/biosdecode.txt; sudo lspci -mm > /tmp/lspcimm.txt; sudo lshw | grep 'pci@' > /tmp/lshwpci.txt; cd /tmp && tar -jcf - gpu_driver.txt gpu_detect.json mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt"
+    $payload = "$bios_info $gi_info lsmod | grep -oE 'nvidia|amdgpu' -m 1 > /tmp/gpu_driver.txt; sudo dmesg | grep 'amdgpu 0000:' > /tmp/dmesgamd.txt; sudo dmidecode -s baseboard-product-name > /tmp/mb_product_name.txt; sudo dmidecode -t 9 > /tmp/dmidecodet9.txt; sudo biosdecode > /tmp/biosdecode.txt; sudo lspci -mm > /tmp/lspcimm.txt; sudo lshw | grep 'pci@' > /tmp/lshwpci.txt; cd /tmp && tar -jcf - gpu_driver.txt dmesgamd.txt mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt"
     $cmd_string = "`"$plink`" -ssh -pw `"$pl_passwd`" -batch user@$remote_ip `"$payload`" > ..\$remote_ip.tar.bz2"
     & $CMD /c $cmd_string 2> $null
     # lets exit if we encounter errors with plink

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -559,11 +559,16 @@ Function Test-If-Empty
         $arr
     )
 
-    if ($arr -and $arr[0] -is [int]) {
-        return ('@(' + ($arr -join ", ") + ')')
-    } elseif ($arr) {
+    if ($arr -and $arr[0] -is [int])
+    {
+        return ('@(' + ($arr -join ', ') + ')')
+    }
+    elseif ($arr)
+    {
         return ('@("' + ($arr -join '", "') + '")')
-    } else {
+    }
+    else
+    {
         return '$null'
     }
 }
@@ -895,8 +900,8 @@ if (-not $config.tests.testMode)
     if ($config.debug.genExpected)
     {
         if (-not (Test-Path .\expected.ps1))
-            {
-                $expected = @'
+        {
+            $expected = @'
 #{0}
 $expected_mb_product_name = "{1}"
 $expected_PIRQ_FOUND = ${2}
@@ -911,27 +916,27 @@ $expected_gpu_ids = @({10})
 $expected_gi_indicators = {11}
 $expected_total_detected_cards = {12}
 '@
-                $expected -f 'expected.ps1',
-                             $mb_product_name,
-                             $PIRQ_FOUND,
-                             (Test-If-Empty $pirq_map),
-                             ('"' + ($pci_busids -join '", "') + '"'),
-                             $pci_missing_devices.Count,
-                             ($pci_info_ids -join ", "),
-                             ('"' + ($pci_info_designations -join '", "') + '"'),
-                             ('"' + ($gpu_busids -join '", "') + '"'),
-                             $gpu_missing_devices.Count,
-                             ('"' + ($gpu_ids -join '", "') + '"'),
-                             (Test-If-Empty $gi_indicators),
-                             $n_detected_cards | Out-File '.\expected.ps1'
-            }
-            Expand-Tar "..\$remote_ip.tar.bz2" .
-            Expand-Tar "$remote_ip.tar" .
-            Update-Tar "$remote_ip.tar" .\expected.ps1
-            Update-Tar "..\$remote_ip.tar.bz2" "$remote_ip.tar"
-            Remove-Item "$remote_ip.tar"
-            Remove-Item .\expected.ps1
-            Write-Verbose "Successfully updated archive with test file."
+            $expected -f 'expected.ps1',
+            $mb_product_name,
+            $PIRQ_FOUND,
+            (Test-If-Empty $pirq_map),
+            ('"' + ($pci_busids -join '", "') + '"'),
+            $pci_missing_devices.Count,
+            ($pci_info_ids -join ', '),
+            ('"' + ($pci_info_designations -join '", "') + '"'),
+            ('"' + ($gpu_busids -join '", "') + '"'),
+            $gpu_missing_devices.Count,
+            ('"' + ($gpu_ids -join '", "') + '"'),
+            (Test-If-Empty $gi_indicators),
+            $n_detected_cards | Out-File '.\expected.ps1'
+        }
+        Expand-Tar "..\$remote_ip.tar.bz2" .
+        Expand-Tar "$remote_ip.tar" .
+        Update-Tar "$remote_ip.tar" .\expected.ps1
+        Update-Tar "..\$remote_ip.tar.bz2" "$remote_ip.tar"
+        Remove-Item "$remote_ip.tar"
+        Remove-Item .\expected.ps1
+        Write-Verbose 'Successfully updated archive with test file.'
     }
 }
 Write-Verbose 'Done!'

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -70,12 +70,12 @@ $octo12_hard_map = @('01', '07', '0c', '0d', '0b', '05', '0a', '04', '09', '03',
 
 Function Find-GPU-Context-Offset
 {
-    $gpu_driver = (Get-Content .\gpu_driver.txt)
-    if ($gpu_driver -eq 'nvidia')
+    $gpu_driver_context = (Get-Content .\gpu_driver.txt)
+    if ($gpu_driver_context -eq 'nvidia')
     {
         return 1
     }
-    elseif ($gpu_driver -eq 'amdgpu')
+    elseif ($gpu_driver_context -eq 'amdgpu')
     {
         if ((Get-Content .\lspcimm.txt | Select-String -Pattern 'Ellesmere').Matches)
         {
@@ -83,7 +83,7 @@ Function Find-GPU-Context-Offset
         }
         return 2
     }
-    return $gpu_driver
+    return $gpu_driver_context
 }
 
 
@@ -161,6 +161,13 @@ Function Read-All-GPU-Busids
         $gdev += $installed_gpu
     }
     return Write-Output -NoEnumerate $gdev
+}
+
+
+Function Get-GPU-Driver
+{
+    $gpu_driver = (Get-Content .\gpu_driver.txt)
+    return $gpu_driver
 }
 
 

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -445,7 +445,7 @@ Function Request-Data
     {
         $gi_info = "head -n 30 /var/log/awesome/$($miner.softwareType)*/console_output.txt > /tmp/console_output.txt;"
     }
-    $payload = "$bios_info $gi_info lsmod | grep -oE 'nvidia|amdgpu' -m 1 > /tmp/gpu_driver.txt; sudo dmesg | grep 'amdgpu 0000:' > /tmp/dmesgamd.txt; sudo dmidecode -s baseboard-product-name > /tmp/mb_product_name.txt; sudo dmidecode -t 9 > /tmp/dmidecodet9.txt; sudo biosdecode > /tmp/biosdecode.txt; sudo lspci -mm > /tmp/lspcimm.txt; sudo lshw | grep 'pci@' > /tmp/lshwpci.txt; cd /tmp && tar -jcf - gpu_driver.txt dmesgamd.txt mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt"
+    $payload = "$bios_info $gi_info lsmod | grep -oE 'nvidia|amdgpu' -m 1 > /tmp/gpu_driver.txt; sudo dmesg | grep 'amdgpu 0000:' > /tmp/dmesgamd.txt; nvidia-smi --query-gpu=gpu_bus_id,name,memory.total --format=csv,noheader > /tmp/nvidiasmi.txt; sudo dmidecode -s baseboard-product-name > /tmp/mb_product_name.txt; sudo dmidecode -t 9 > /tmp/dmidecodet9.txt; sudo biosdecode > /tmp/biosdecode.txt; sudo lspci -mm > /tmp/lspcimm.txt; sudo lshw | grep 'pci@' > /tmp/lshwpci.txt; cd /tmp && tar -jcf - gpu_driver.txt dmesgamd.txt nvidiasmi.txt mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt"
     $cmd_string = "`"$plink`" -ssh -pw `"$pl_passwd`" -batch user@$remote_ip `"$payload`" > ..\$remote_ip.tar.bz2"
     & $CMD /c $cmd_string 2> $null
     # lets exit if we encounter errors with plink

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -459,14 +459,14 @@ Function Request-Data
     $bios_info = ''
     if ($config.debug.debugBIOS)
     {
-        $bios_info = 'for d in system-manufacturer system-product-name bios-release-date bios-version; do echo "${d^} : " $(sudo dmidecode -s $d); done > /tmp/dmidecodebios.txt;'
+        $bios_info = "for d in system-manufacturer system-product-name bios-release-date bios-version; do echo `"`${d^} : `" `$(echo `"$pl_passwd`" | sudo -S -k dmidecode -s `$d); done > /tmp/dmidecodebios.txt;"
     }
     $gi_info = ''
     if ($config.options.checkGI)
     {
         $gi_info = "head -n 30 /var/log/awesome/$($miner.softwareType)*/console_output.txt > /tmp/console_output.txt;"
     }
-    $payload = "$bios_info $gi_info lsmod | grep -oE 'nvidia|amdgpu' -m 1 > /tmp/gpu_driver.txt; sudo dmesg | grep 'amdgpu 0000:' > /tmp/dmesgamd.txt; nvidia-smi --query-gpu=gpu_bus_id,name,memory.total --format=csv,noheader > /tmp/nvidiasmi.txt; sudo dmidecode -s baseboard-product-name > /tmp/mb_product_name.txt; sudo dmidecode -t 9 > /tmp/dmidecodet9.txt; sudo biosdecode > /tmp/biosdecode.txt; sudo lspci -mm > /tmp/lspcimm.txt; sudo lshw | grep 'pci@' > /tmp/lshwpci.txt; cd /tmp && tar -jcf - gpu_driver.txt dmesgamd.txt nvidiasmi.txt mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt"
+    $payload = "$bios_info $gi_info lsmod | grep -oE 'nvidia|amdgpu' -m 1 > /tmp/gpu_driver.txt; echo `"$pl_passwd`" | sudo -S -k dmesg | grep 'amdgpu 0000:' > /tmp/dmesgamd.txt; nvidia-smi --query-gpu=gpu_bus_id,name,memory.total --format=csv,noheader > /tmp/nvidiasmi.txt; echo `"$pl_passwd`" | sudo -S -k dmidecode -s baseboard-product-name > /tmp/mb_product_name.txt; echo `"$pl_passwd`" | sudo -S -k dmidecode -t 9 > /tmp/dmidecodet9.txt; echo `"$pl_passwd`" | sudo -S -k biosdecode > /tmp/biosdecode.txt; lspci -mm > /tmp/lspcimm.txt; echo `"$pl_passwd`" | sudo -S -k lshw | grep 'pci@' > /tmp/lshwpci.txt; cd /tmp && tar -jcf - gpu_driver.txt dmesgamd.txt nvidiasmi.txt mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt"
     $cmd_string = "`"$plink`" -ssh -pw `"$pl_passwd`" -batch user@$remote_ip `"$payload`" > ..\$remote_ip.tar.bz2"
     & $CMD /c $cmd_string 2> $null
     # lets exit if we encounter errors with plink

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -455,7 +455,7 @@ Function Request-Data
 {
     # Need to make manual connection first to accept remote host key
     Write-Output 'Ensuring remote host is trusted and can connect...'
-    Write-Output 'y' | & $plink -ssh  user@$remote_ip 2> $null
+    Write-Output 'y' | & $plink -ssh  $username@$remote_ip 2> $null
     $bios_info = '#'
     $gi_info = '#'
     if ($config.debug.debugBIOS)
@@ -493,7 +493,7 @@ else
     cd /tmp && tar -jcf - gpu_driver.txt dmesgamd.txt nvidiasmi.txt mb_product_name.txt dmidecodebios.txt dmidecodet9.txt biosdecode.txt lspcimm.txt lshwpci.txt console_output.txt
 fi
 "@ | Out-File -Encoding ascii -FilePath .\payload
-    $cmd_string = "`"$plink`" -ssh -pw `"$pl_passwd`" -batch user@$remote_ip -m .\payload > ..\$remote_ip.tar.bz2"
+    $cmd_string = "`"$plink`" -ssh -pw `"$pl_passwd`" -batch $username@$remote_ip -m .\payload > ..\$remote_ip.tar.bz2"
     & $CMD /c $cmd_string 2> $null
     # lets exit if we encounter errors with plink
     if ($LASTEXITCODE -eq 1) { Throw 'ERROR (Connection Error: unable to connect to remote IP. Supplied password may not have been accepted)' }
@@ -735,12 +735,17 @@ if ($config.debug.debugMode)
 $CMD = 'C:\Windows\System32\cmd.exe'
 
 $remote_ip = $config.options.input.remoteIP
+$username = $config.options.input.username
 $remote_passwd = $config.options.input.passwd
 $search_list = ($config.options.input.filterList).Split(',')
 
 # Comment when debugging
 if (-not $config.debug.debugMode -and -not $config.tests.testMode)
 {
+    if (! $username.Length)
+    {
+        $username = 'user'
+    }
     if (! $remote_passwd.Length)
     {
         if (! $env:Default) { Throw 'ERROR (Missing Credentials: No password for remote target supplied)' }
@@ -755,7 +760,7 @@ if (-not $config.debug.debugMode -and -not $config.tests.testMode)
     if ($putty -and $config.options.checkPutty)
     {
         # Launch a new PuTTY session for further debugging
-        $cmd_args = "-ssh -l user -pw `"$pl_passwd`" $remote_ip"
+        $cmd_args = "-ssh -l $username -pw `"$pl_passwd`" $remote_ip"
         Start-Process -FilePath $putty -ArgumentList $cmd_args
     }
     $miner = Find-GPU-Miner

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -167,6 +167,10 @@ Function Read-All-GPU-Busids
 Function Get-GPU-Driver
 {
     $gpu_driver = (Get-Content .\gpu_driver.txt)
+    if (! $gpu_driver)
+    {
+        Throw 'ERROR (Unknown GPU Driver: unable to find gpu driver.)'
+    }
     return $gpu_driver
 }
 

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -194,7 +194,8 @@ Function Get-GPU-Info
         {
             $name = (Get-Content .\lspcimm.txt | Select-String -Pattern "$bus").Line | Show-Column -Delimiter '"' -Column 5
             $mem = ($gpu_data | Select-String -Pattern "amdgpu 0000:${bus}:.*?VRAM:\s([^\s]+)").Matches.Groups[1].Value
-        } elseif ($gpu_type -eq 'nvidia')
+        }
+        elseif ($gpu_type -eq 'nvidia')
         {
             $name = ($gpu_data | Select-String -Pattern "00000000:$bus").Line | Show-Column -Delimiter ',' -Column 1
             $mem = ($gpu_data | Select-String -Pattern "00000000:$bus").Line | Show-Column -Delimiter ',' -Column 2
@@ -466,7 +467,7 @@ Function Request-Data
     {
         $gi_info = "    head -n 30 /var/log/awesome/$($miner.softwareType)*/console_output.txt > /tmp/console_output.txt;"
     }
-@"
+    @"
 function check_depends {
     echo `"$pl_passwd`" | sudo -S -k apt-get update &> /dev/null
     for d in dmidecode lshw; do
@@ -497,7 +498,8 @@ fi
     & $CMD /c $cmd_string 2> $null
     # lets exit if we encounter errors with plink
     if ($LASTEXITCODE -eq 1) { Throw 'ERROR (Connection Error: unable to connect to remote IP. Supplied password may not have been accepted)' }
-    if ((Get-Content "..\$remote_ip.tar.bz2" | Select-String -Pattern "ERROR").Line) {
+    if ((Get-Content "..\$remote_ip.tar.bz2" | Select-String -Pattern 'ERROR').Line)
+    {
         Throw 'ERROR (Permission Error: Supplied User is not sudoer)'
     }
     Expand-Tar "..\$remote_ip.tar.bz2" .

--- a/gpu_lookup_tableGUI.ps1
+++ b/gpu_lookup_tableGUI.ps1
@@ -70,7 +70,7 @@ $octo12_hard_map = @('01', '07', '0c', '0d', '0b', '05', '0a', '04', '09', '03',
 
 Function Find-GPU-Context-Offset
 {
-    $gpu_driver_context = (Get-Content .\gpu_driver.txt)
+    $gpu_driver_context = Get-GPU-Driver
     if ($gpu_driver_context -eq 'nvidia')
     {
         return 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
make "distro-agnostic" with Ubuntu distros
<!-- if adding support for baseboards, use the BASEBOARD_SUPPORT_TEMPLATE instead -->

<!-- if fixing an existing issue -->
Fixes #2

## Implemention/Fixes
<!-- Provide a short summary of changes and any fixes needed -->
Get GPU info for all Ubuntu-based distros instead of gpu-detect.json in HiveOS
